### PR TITLE
Fix twitter link

### DIFF
--- a/data/site.yml
+++ b/data/site.yml
@@ -12,7 +12,7 @@ sponsorDeck_en: https://bit.ly/2TYGnsY
 socialMedia:
   - name: Twitter
     title: '@rubyconftw'
-    link: rubyconftw
+    link: https://twitter.com/rubyconftw
   - name: Facebook
     title: RubyConf Taiwan
     link: https://www.facebook.com/rubyconftw/


### PR DESCRIPTION
The twitter link at the bottom of the footer was leading to  `https://2019.rubyconf.tw/rubyconftw` because it was incomplete. 

![Screen Shot 2019-06-17 at 2 20 30 PM](https://user-images.githubusercontent.com/1251946/59626941-18e77300-910b-11e9-9ad7-62b96929ddb8.png)
